### PR TITLE
Notarization integration

### DIFF
--- a/sources/fractional.move
+++ b/sources/fractional.move
@@ -169,6 +169,7 @@ public entry fun merge_back<F>(
 
 /// Manually destroy an empty vault and return the TreasuryCap.
 /// Anyone can call this to clean up the state (permissionless).
+#[allow(lint(freezing_capability))]
 public entry fun destroy_empty_vault<F>(
     vault: FractionalVault<F>,
     _ctx: &mut TxContext

--- a/sources/ltc1.move
+++ b/sources/ltc1.move
@@ -552,3 +552,10 @@ public(package) fun add_fraction_balance(
     token.balance = token.balance + balance;
     token.claimed_revenue = token.claimed_revenue + claimed_revenue;
 }
+
+// ==================== Testing Functions ====================
+
+#[test_only]
+public fun bond_package_id(bond: &OwnerBond): ID {
+    bond.package_id
+}

--- a/tests/ltc1_tests.move
+++ b/tests/ltc1_tests.move
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Federico Abrignani. All rights reserved.
 /// Unit tests for LTC1
-/// Test integration with registry and core ltc1 features
+/// Test integration with registry and core ltc1 features (notarization-based API)
 
 #[test_only]
 module nplex::ltc1_tests {
@@ -9,8 +9,11 @@ module nplex::ltc1_tests {
     use iota::test_scenario::{Self, Scenario, next_tx, ctx};
     use iota::coin::{Self, Coin};
     use iota::iota::IOTA;
-    use iota::clock;
+    use iota::clock::{Self};
     use std::string::{Self};
+    use iota_notarization::notarization;
+    use iota_notarization::dynamic_notarization;
+    use iota_notarization::timelock;
 
     // Test Users
     const ADMIN: address = @0xAD;
@@ -33,22 +36,85 @@ module nplex::ltc1_tests {
         next_tx(scenario, ADMIN);
         registry::init_for_testing(ctx(scenario));
 
-        // 2. Register Hash & Authorize LTC1
+        // 2. Authorize LTC1 executor (notarization registration is done per-test)
         next_tx(scenario, ADMIN);
         let mut registry = test_scenario::take_shared<NPLEXRegistry>(scenario);
         let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(scenario);
-        let clock = clock::create_for_testing(ctx(scenario));
 
-        registry::register_hash(&mut registry, &admin_cap, DOCUMENT_HASH, OWNER, &clock, ctx(scenario));
         registry::add_executor<LTC1Witness>(&mut registry, &admin_cap);
 
-        clock::destroy_for_testing(clock);
         test_scenario::return_shared(registry);
         test_scenario::return_to_sender(scenario, admin_cap);
     }
 
     fun mint_coins(amount: u64, scenario: &mut Scenario): Coin<IOTA> {
         coin::mint_for_testing<IOTA>(amount, ctx(scenario))
+    }
+
+    /// Helper: creates a real Notarization<u256> object, registers it in the registry,
+    /// then calls the production create_contract.
+    /// Flow: ADMIN tx (create notarization + register) → OWNER tx (create_contract)
+    fun create_contract_with_notarization(scenario: &mut Scenario): ID {
+        // Step 1: ADMIN creates notarization object and registers its real ID
+        next_tx(scenario, ADMIN);
+        {
+            let mut registry = test_scenario::take_shared<NPLEXRegistry>(scenario);
+            let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(scenario);
+            let clock = clock::create_for_testing(ctx(scenario));
+
+            // Create a real Notarization<u256> object
+            let state = notarization::new_state_from_generic<u256>(DOCUMENT_HASH, option::none());
+            let notarization_obj = dynamic_notarization::new<u256>(
+                state, option::none(), option::none(), timelock::none(), &clock, ctx(scenario)
+            );
+
+            // Register the real notarization ID
+            let real_id = object::id(&notarization_obj);
+            registry::register_notarization(
+                &mut registry, &admin_cap, real_id, DOCUMENT_HASH, OWNER, &clock, ctx(scenario)
+            );
+
+            dynamic_notarization::transfer(notarization_obj, OWNER, &clock, ctx(scenario));
+
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(registry);
+            test_scenario::return_to_sender(scenario, admin_cap);
+        };
+
+        // Step 2: OWNER uses the notarization to create the contract
+        next_tx(scenario, OWNER);
+        {
+            let mut registry = test_scenario::take_shared<NPLEXRegistry>(scenario);
+            let notarization_obj = test_scenario::take_from_sender<notarization::Notarization<u256>>(scenario);
+            let clock = clock::create_for_testing(ctx(scenario));
+
+            ltc1::create_contract<IOTA>(
+                &mut registry,
+                string::utf8(b"LTC1 Package"),
+                &notarization_obj,
+                TOTAL_SUPPLY,
+                TOKEN_PRICE,
+                NOMINAL_VALUE,
+                SPLIT_BPS,
+                string::utf8(b"ipfs://metadata"),
+                &clock,
+                ctx(scenario)
+            );
+
+            notarization::destroy(notarization_obj, &clock);
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(registry);
+        };
+
+        // Step 3: Retrieve package_id from the OwnerBond
+        next_tx(scenario, OWNER);
+        let package_id = {
+            let bond = test_scenario::take_from_sender<OwnerBond>(scenario);
+            let id = ltc1::bond_package_id(&bond);
+            test_scenario::return_to_sender(scenario, bond);
+            id
+        };
+        package_id
     }
 
     /// Helper: Admin authorizes + executes sales open for a package
@@ -89,37 +155,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract (Owner)
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 1.5 Get Package ID from Registry
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-            let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 1.6 Open Sales
         open_sales(&mut scenario, package_id);
@@ -281,37 +317,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract (Owner) with 50% split (Max Sellable = 500)
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS, // 5000
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 1.5 Get Package ID from Registry
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-            let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 1.6 Open Sales
         open_sales(&mut scenario, package_id);
@@ -343,8 +349,8 @@ module nplex::ltc1_tests {
     // Scenario: Admin forgets to register document hash. Creator calls create_contract.
     // System must reject the creation attempt.
     #[test]
-    #[expected_failure(abort_code = registry::E_HASH_NOT_APPROVED)]
-    fun test_create_contract_not_registered_hash() {
+    #[expected_failure(abort_code = registry::E_NOTARIZATION_NOT_APPROVED)]
+    fun test_create_contract_not_registered_notarization() {
         let mut scenario = test_scenario::begin(ADMIN);
         
         // Setup: Init registry, Authorize Witness, BUT DO NOT Register Hash
@@ -358,23 +364,26 @@ module nplex::ltc1_tests {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
 
-            // ONLY Authorize Witness
+            // ONLY Authorize Witness (no notarization registered)
             registry::add_executor<LTC1Witness>(&mut registry, &admin_cap);
 
             test_scenario::return_shared(registry);
             test_scenario::return_to_sender(&scenario, admin_cap);
         };
 
-        // Try to create contract (Should Fail)
+        // Try to create contract (Should Fail) - create notarization but don't register it
         next_tx(&mut scenario, OWNER);
         {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let clock = clock::create_for_testing(ctx(&mut scenario));
+            let state = notarization::new_state_from_generic<u256>(DOCUMENT_HASH, option::none());
+            let notarization_obj = dynamic_notarization::new<u256>(
+                state, option::none(), option::none(), timelock::none(), &clock, ctx(&mut scenario)
+            );
             ltc1::create_contract<IOTA>(
                 &mut registry,
                 string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
+                &notarization_obj,
                 TOTAL_SUPPLY,
                 TOKEN_PRICE,
                 NOMINAL_VALUE,
@@ -383,6 +392,7 @@ module nplex::ltc1_tests {
                 &clock,
                 ctx(&mut scenario)
             );
+            notarization::destroy(notarization_obj, &clock);
             clock::destroy_for_testing(clock);
             test_scenario::return_shared(registry);
         };
@@ -413,24 +423,30 @@ module nplex::ltc1_tests {
             let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
             let clock = clock::create_for_testing(ctx(&mut scenario));
 
-            // ONLY Register Hash
-            registry::register_hash(&mut registry, &admin_cap, DOCUMENT_HASH, OWNER, &clock, ctx(&mut scenario));
+            // Create real notarization object and register it, but DO NOT authorize witness
+            let state = notarization::new_state_from_generic<u256>(DOCUMENT_HASH, option::none());
+            let notarization_obj = dynamic_notarization::new<u256>(
+                state, option::none(), option::none(), timelock::none(), &clock, ctx(&mut scenario)
+            );
+            let real_id = object::id(&notarization_obj);
+            registry::register_notarization(&mut registry, &admin_cap, real_id, DOCUMENT_HASH, OWNER, &clock, ctx(&mut scenario));
+            dynamic_notarization::transfer(notarization_obj, OWNER, &clock, ctx(&mut scenario));
 
             clock::destroy_for_testing(clock);
             test_scenario::return_shared(registry);
             test_scenario::return_to_sender(&scenario, admin_cap);
         };
 
-        // Try to create contract (Should Fail)
+        // Try to create contract (Should Fail - witness not authorized)
         next_tx(&mut scenario, OWNER);
         {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
+            let notarization_obj = test_scenario::take_from_sender<notarization::Notarization<u256>>(&scenario);
             let clock = clock::create_for_testing(ctx(&mut scenario));
             ltc1::create_contract<IOTA>(
                 &mut registry,
                 string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
+                &notarization_obj,
                 TOTAL_SUPPLY,
                 TOKEN_PRICE,
                 NOMINAL_VALUE,
@@ -439,6 +455,7 @@ module nplex::ltc1_tests {
                 &clock,
                 ctx(&mut scenario)
             );
+            notarization::destroy(notarization_obj, &clock);
             clock::destroy_for_testing(clock);
             test_scenario::return_shared(registry);
         };
@@ -457,37 +474,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract (Owner)
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 2. Get Package ID
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-            let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 3. Authorize Transfer (Admin)
         next_tx(&mut scenario, ADMIN);
@@ -544,37 +531,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract (Owner)
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 1.5 Get Package ID
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-             let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 1.6 Open Sales
         open_sales(&mut scenario, package_id);
@@ -635,37 +592,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract (Owner)
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 1.5 Get Package ID
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-             let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 1.6 Open Sales
         open_sales(&mut scenario, package_id);
@@ -861,11 +788,14 @@ module nplex::ltc1_tests {
         {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let clock = clock::create_for_testing(ctx(&mut scenario));
+            let state = notarization::new_state_from_generic<u256>(DOCUMENT_HASH, option::none());
+            let notarization_obj = dynamic_notarization::new<u256>(
+                state, option::none(), option::none(), timelock::none(), &clock, ctx(&mut scenario)
+            );
             ltc1::create_contract<IOTA>(
                 &mut registry,
                 string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
+                &notarization_obj,
                 100, // TOO LOW (Min is 1B)
                 TOKEN_PRICE,
                 NOMINAL_VALUE,
@@ -874,6 +804,7 @@ module nplex::ltc1_tests {
                 &clock,
                 ctx(&mut scenario)
             );
+            notarization::destroy(notarization_obj, &clock);
             clock::destroy_for_testing(clock);
             test_scenario::return_shared(registry);
         };
@@ -894,11 +825,14 @@ module nplex::ltc1_tests {
         {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let clock = clock::create_for_testing(ctx(&mut scenario));
+            let state = notarization::new_state_from_generic<u256>(DOCUMENT_HASH, option::none());
+            let notarization_obj = dynamic_notarization::new<u256>(
+                state, option::none(), option::none(), timelock::none(), &clock, ctx(&mut scenario)
+            );
             ltc1::create_contract<IOTA>(
                 &mut registry,
                 string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
+                &notarization_obj,
                 TOTAL_SUPPLY,
                 TOKEN_PRICE,
                 NOMINAL_VALUE,
@@ -907,6 +841,7 @@ module nplex::ltc1_tests {
                 &clock,
                 ctx(&mut scenario)
             );
+            notarization::destroy(notarization_obj, &clock);
             clock::destroy_for_testing(clock);
             test_scenario::return_shared(registry);
         };
@@ -925,36 +860,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract & Get ID
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-             let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 1.6 Open Sales
         open_sales(&mut scenario, package_id);
@@ -1033,53 +939,60 @@ module nplex::ltc1_tests {
     fun test_update_authorized_creator() {
         let mut scenario = test_scenario::begin(ADMIN);
         
-        // 1. Initial Setup: Register Hash with OWNER (A1)
+        // 1. Initial Setup: Create notarization, register with OWNER (A1)
         next_tx(&mut scenario, ADMIN);
         registry::init_for_testing(ctx(&mut scenario));
         
         next_tx(&mut scenario, ADMIN);
-        let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-        let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
-        let clock = clock::create_for_testing(ctx(&mut scenario));
-        
-        registry::register_hash(&mut registry, &admin_cap, DOCUMENT_HASH, OWNER, &clock, ctx(&mut scenario));
-        registry::add_executor<LTC1Witness>(&mut registry, &admin_cap); // Authorize LTC1
-        
-        clock::destroy_for_testing(clock);
-        test_scenario::return_shared(registry);
-        test_scenario::return_to_sender(&scenario, admin_cap);
-
-        // 2. Update Authorized Creator to NEW_OWNER (A2)
-        next_tx(&mut scenario, ADMIN);
-        let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-        let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
-        
-        registry::update_authorized_creator(&mut registry, &admin_cap, DOCUMENT_HASH, NEW_OWNER);
-        
-        test_scenario::return_shared(registry);
-        test_scenario::return_to_sender(&scenario, admin_cap);
+        {
+            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
+            let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
+            let clock = clock::create_for_testing(ctx(&mut scenario));
+            
+            // Create real notarization object
+            let state = notarization::new_state_from_generic<u256>(DOCUMENT_HASH, option::none());
+            let notarization_obj = dynamic_notarization::new<u256>(
+                state, option::none(), option::none(), timelock::none(), &clock, ctx(&mut scenario)
+            );
+            let real_id = object::id(&notarization_obj);
+            
+            registry::register_notarization(&mut registry, &admin_cap, real_id, DOCUMENT_HASH, OWNER, &clock, ctx(&mut scenario));
+            registry::add_executor<LTC1Witness>(&mut registry, &admin_cap);
+            
+            // 2. Update Authorized Creator to NEW_OWNER (A2)
+            registry::update_authorized_creator(&mut registry, &admin_cap, real_id, NEW_OWNER);
+            
+            dynamic_notarization::transfer(notarization_obj, NEW_OWNER, &clock, ctx(&mut scenario));
+            
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(registry);
+            test_scenario::return_to_sender(&scenario, admin_cap);
+        };
 
         // 3. T1: NEW_OWNER (A2) creates contract -> Success
         next_tx(&mut scenario, NEW_OWNER);
-        let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-        let clock = clock::create_for_testing(ctx(&mut scenario));
-        
-        ltc1::create_contract<IOTA>(
-            &mut registry,
-            string::utf8(b"LTC1 Package"),
-            DOCUMENT_HASH,
-            object::id_from_address(@0xA11), // Dummy Notary ID
-            TOTAL_SUPPLY,
-            TOKEN_PRICE,
-            NOMINAL_VALUE,
-            SPLIT_BPS,
-            string::utf8(b"ipfs://metadata"),
-            &clock,
-            ctx(&mut scenario)
-        );
-        
-        clock::destroy_for_testing(clock);
-        test_scenario::return_shared(registry);
+        {
+            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
+            let notarization_obj = test_scenario::take_from_sender<notarization::Notarization<u256>>(&scenario);
+            let clock = clock::create_for_testing(ctx(&mut scenario));
+            
+            ltc1::create_contract<IOTA>(
+                &mut registry,
+                string::utf8(b"LTC1 Package"),
+                &notarization_obj,
+                TOTAL_SUPPLY,
+                TOKEN_PRICE,
+                NOMINAL_VALUE,
+                SPLIT_BPS,
+                string::utf8(b"ipfs://metadata"),
+                &clock,
+                ctx(&mut scenario)
+            );
+            
+            notarization::destroy(notarization_obj, &clock);
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(registry);
+        };
         test_scenario::end(scenario);
     }
 
@@ -1088,53 +1001,60 @@ module nplex::ltc1_tests {
     fun test_update_authorized_creator_failure_old_owner() {
         let mut scenario = test_scenario::begin(ADMIN);
         
-        // 1. Initial Setup: Register Hash with OWNER (A1)
+        // 1. Initial Setup: Create notarization, register with OWNER (A1)
         next_tx(&mut scenario, ADMIN);
         registry::init_for_testing(ctx(&mut scenario));
         
         next_tx(&mut scenario, ADMIN);
-        let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-        let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
-        let clock = clock::create_for_testing(ctx(&mut scenario));
-        
-        registry::register_hash(&mut registry, &admin_cap, DOCUMENT_HASH, OWNER, &clock, ctx(&mut scenario));
-        registry::add_executor<LTC1Witness>(&mut registry, &admin_cap);
-        
-        clock::destroy_for_testing(clock);
-        test_scenario::return_shared(registry);
-        test_scenario::return_to_sender(&scenario, admin_cap);
-
-        // 2. Update Authorized Creator to NEW_OWNER (A2)
-        next_tx(&mut scenario, ADMIN);
-        let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-        let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
-        
-        registry::update_authorized_creator(&mut registry, &admin_cap, DOCUMENT_HASH, NEW_OWNER);
-        
-        test_scenario::return_shared(registry);
-        test_scenario::return_to_sender(&scenario, admin_cap);
+        {
+            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
+            let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
+            let clock = clock::create_for_testing(ctx(&mut scenario));
+            
+            // Create real notarization object
+            let state = notarization::new_state_from_generic<u256>(DOCUMENT_HASH, option::none());
+            let notarization_obj = dynamic_notarization::new<u256>(
+                state, option::none(), option::none(), timelock::none(), &clock, ctx(&mut scenario)
+            );
+            let real_id = object::id(&notarization_obj);
+            
+            registry::register_notarization(&mut registry, &admin_cap, real_id, DOCUMENT_HASH, OWNER, &clock, ctx(&mut scenario));
+            registry::add_executor<LTC1Witness>(&mut registry, &admin_cap);
+            
+            // Update Authorized Creator to NEW_OWNER (A2)
+            registry::update_authorized_creator(&mut registry, &admin_cap, real_id, NEW_OWNER);
+            
+            dynamic_notarization::transfer(notarization_obj, OWNER, &clock, ctx(&mut scenario));
+            
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(registry);
+            test_scenario::return_to_sender(&scenario, admin_cap);
+        };
 
         // 3. T2: OWNER (A1) tries to create contract -> Error
         next_tx(&mut scenario, OWNER);
-        let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-        let clock = clock::create_for_testing(ctx(&mut scenario));
-        
-        ltc1::create_contract<IOTA>(
-            &mut registry,
-            string::utf8(b"LTC1 Package"),
-            DOCUMENT_HASH,
-            object::id_from_address(@0xA11), // Dummy Notary ID
-            TOTAL_SUPPLY,
-            TOKEN_PRICE,
-            NOMINAL_VALUE,
-            SPLIT_BPS,
-            string::utf8(b"ipfs://metadata"),
-            &clock,
-            ctx(&mut scenario)
-        );
-        
-        clock::destroy_for_testing(clock);
-        test_scenario::return_shared(registry);
+        {
+            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
+            let notarization_obj = test_scenario::take_from_sender<notarization::Notarization<u256>>(&scenario);
+            let clock = clock::create_for_testing(ctx(&mut scenario));
+            
+            ltc1::create_contract<IOTA>(
+                &mut registry,
+                string::utf8(b"LTC1 Package"),
+                &notarization_obj,
+                TOTAL_SUPPLY,
+                TOKEN_PRICE,
+                NOMINAL_VALUE,
+                SPLIT_BPS,
+                string::utf8(b"ipfs://metadata"),
+                &clock,
+                ctx(&mut scenario)
+            );
+            
+            notarization::destroy(notarization_obj, &clock);
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(registry);
+        };
         test_scenario::end(scenario);
     }
 
@@ -1150,37 +1070,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 2. Get Package ID
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-            let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 3. Admin authorizes close sales
         next_tx(&mut scenario, ADMIN);
@@ -1227,37 +1117,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 2. Get Package ID
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-            let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 3. Admin closes sales
         next_tx(&mut scenario, ADMIN);
@@ -1331,37 +1191,7 @@ module nplex::ltc1_tests {
         setup_registry(&mut scenario);
 
         // 1. Create Contract
-        next_tx(&mut scenario, OWNER);
-        {
-            let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let clock = clock::create_for_testing(ctx(&mut scenario));
-            ltc1::create_contract<IOTA>(
-                &mut registry,
-                string::utf8(b"LTC1 Package"),
-                DOCUMENT_HASH,
-                object::id_from_address(@0xA11), // Dummy Notary ID
-                TOTAL_SUPPLY,
-                TOKEN_PRICE,
-                NOMINAL_VALUE,
-                SPLIT_BPS,
-                string::utf8(b"ipfs://metadata"),
-                &clock,
-                ctx(&mut scenario)
-            );
-            clock::destroy_for_testing(clock);
-            test_scenario::return_shared(registry);
-        };
-
-        // 2. Get Package ID
-        next_tx(&mut scenario, ADMIN);
-        let package_id = {
-            let registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
-            let info = registry::get_hash_info(&registry, DOCUMENT_HASH);
-            let contract_id_opt = registry::hash_contract_id(&info);
-            let id = std::option::extract(&mut std::option::some(std::option::destroy_some(contract_id_opt)));
-            test_scenario::return_shared(registry);
-            id
-        };
+        let package_id = create_contract_with_notarization(&mut scenario);
 
         // 2.5 Open Sales first
         open_sales(&mut scenario, package_id);


### PR DESCRIPTION
This pull request makes significant improvements to the notarization flow, terminology, and testing infrastructure across the `registry`, `ltc1`, and `fractional` modules, as well as their associated tests. The main focus is on renaming and refactoring types and functions from "Hash" terminology to "Notarization", updating function signatures for consistency, and modernizing test logic to use explicit notarization objects and IDs. These changes improve code clarity, maintainability, and alignment with the business logic.

**Notarization Terminology Refactor:**

- Renamed core types and functions from `HashInfo`, `HashClaim`, and related accessors to `NotarizationInfo`, `NotarizationClaim`, and corresponding accessors throughout `sources/registry.move`, updating all usages accordingly. [[1]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L63-R63) [[2]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L82-R82) [[3]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L95-R95) [[4]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L170-R174) [[5]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L183-R183) [[6]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L282-R319) [[7]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L386-R387) [[8]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L399-R412) [[9]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L425-R451) [[10]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L473-R474)

- Updated all registry functions and storage to use the new notarization types, including claim, bind, info retrieval, and revocation checks. [[1]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L282-R319) [[2]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L386-R387) [[3]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L399-R412) [[4]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L425-R451) [[5]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L473-R474)

**API and Function Signature Updates:**

- Changed registry entry functions to consistently use `&mut TxContext` instead of `&TxContext` for mutability and future-proofing. [[1]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L170-R174) [[2]](diffhunk://#diff-873a995d010a4f8fb2a35f1c807ef70c707ccca294c5f8ba17ba2427190bb1a1R172)

**Testing Infrastructure Improvements:**

- Refactored fractional and registry tests to use explicit notarization objects and IDs, replacing legacy hash-based flows. Tests now create, transfer, and destroy notarization objects as part of the contract creation process, and retrieve package IDs directly from `OwnerBond` using a new accessor. [[1]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5L34-R34) [[2]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5R43-R45) [[3]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5L66-R108) [[4]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5R117-R127) [[5]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5L497-R526) [[6]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5R535-R540) [[7]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5R549-R561) [[8]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L3-R3) [[9]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30R18-R39) [[10]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L41-R54)

- Added a new test-only accessor function `bond_package_id` to `ltc1.move` for retrieving the package ID from an `OwnerBond` in tests.

**General Code Quality:**

- Updated and clarified documentation and comments to reflect the new notarization terminology and logic. [[1]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L3-R3) [[2]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30R18-R39) [[3]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L41-R54)

These changes together modernize the codebase, making notarization flows more explicit and easier to test and reason about.