### PR TITLE
Require notarizations for transfers and sales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Move.lock
 fake_eurc/
 deployed_addresses.json
 MIDDLEWARE_GUIDE.md
+MIGRATION_REPORT.md
+.agent/

--- a/tests/registry_tests.move
+++ b/tests/registry_tests.move
@@ -425,7 +425,7 @@ module nplex::registry_tests {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
             
-            registry::authorize_transfer(&mut registry, &admin_cap, package_id, new_owner);
+            registry::authorize_transfer(&mut registry, &admin_cap, package_id, new_owner, verified_notarization_id());
             
             // Assert: Ticket Created
             assert!(registry::is_transfer_authorized(&registry, package_id), 1);
@@ -466,7 +466,7 @@ module nplex::registry_tests {
         {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
-            registry::authorize_transfer(&mut registry, &admin_cap, package_id, authorized_owner);
+            registry::authorize_transfer(&mut registry, &admin_cap, package_id, authorized_owner, verified_notarization_id());
             test_scenario::return_shared(registry);
             test_scenario::return_to_sender(&scenario, admin_cap);
         };
@@ -496,7 +496,7 @@ module nplex::registry_tests {
         {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
-            registry::authorize_transfer(&mut registry, &admin_cap, package_id, new_owner);
+            registry::authorize_transfer(&mut registry, &admin_cap, package_id, new_owner, verified_notarization_id());
             test_scenario::return_shared(registry);
             test_scenario::return_to_sender(&scenario, admin_cap);
         };
@@ -609,7 +609,7 @@ module nplex::registry_tests {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
             
-            registry::authorize_sales_toggle(&mut registry, &admin_cap, contract_id, false);
+            registry::authorize_sales_toggle(&mut registry, &admin_cap, contract_id, false, verified_notarization_id());
             
             // Assert: Ticket Created
             assert!(registry::is_sales_toggle_authorized(&registry, contract_id), 1);
@@ -650,7 +650,7 @@ module nplex::registry_tests {
         {
             let mut registry = test_scenario::take_shared<NPLEXRegistry>(&scenario);
             let admin_cap = test_scenario::take_from_sender<NPLEXAdminCap>(&scenario);
-            registry::authorize_sales_toggle(&mut registry, &admin_cap, contract_id, false);
+            registry::authorize_sales_toggle(&mut registry, &admin_cap, contract_id, false, verified_notarization_id());
             test_scenario::return_shared(registry);
             test_scenario::return_to_sender(&scenario, admin_cap);
         };


### PR DESCRIPTION
This pull request strengthens the security and auditability of bond transfer and sales toggle authorizations in the `NPLEXRegistry` by requiring every authorization to be explicitly tied to a valid, non-revoked notarization. It introduces new data structures to track these relationships, updates core logic to enforce notarization checks, and modifies tests to accommodate the new requirements.

**Authorization Model Improvements:**

* Introduced `NotarizedTransfer` and `NotarizedSaleToggle` structs to encapsulate transfer and sales toggle authorizations, each referencing the backing notarization and associated parameters. The registry's `authorized_transfers` and `authorized_sales_toggles` tables now store these structs instead of simple values. [[1]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L83-R86) [[2]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8R110-R125)
* Updated the `authorize_transfer` and `authorize_sales_toggle` entry functions to require a `notarization_id` parameter. These functions now verify that the provided notarization exists and is not revoked before creating an authorization.

**Enforcement of Notarization Validity:**

* Enhanced the `consume_transfer_ticket` and `consume_sales_toggle_ticket` functions to check that the backing notarization for each authorization is still valid (not revoked) at the time of consumption, adding an extra layer of runtime security. [[1]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L323-R360) [[2]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L337-R388) [[3]](diffhunk://#diff-3e06cc032fc568dbe01b8557206f69f9df9c4f9763d346a27ad72e41792f34e8L358-R409)

**Test Suite Updates:**

* Refactored all test usages of `authorize_transfer` and `authorize_sales_toggle` to provide a valid notarization ID, and added helpers to register and reference a stable test notarization for authorizations. This ensures all tests reflect the new requirement that authorizations must be backed by a valid notarization. [[1]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5R55-R63) [[2]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5R73-R83) [[3]](diffhunk://#diff-f9c7da11a222b11db48244f9505ca5ee22a1b4ba549e4bbae05ab09a4beb9ee5L136-R148) [[4]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97R27-R57) [[5]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97L127-R139) [[6]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97L489-R502) [[7]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97L644-R657) [[8]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97L1080-R1093) [[9]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97L1127-R1140) [[10]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97L1146-R1159) [[11]](diffhunk://#diff-64c4c2b5346b7feaf2405486a0cd71528f19447c22f8f8e84fe55d03eec46b97L1218-R1231) [[12]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L428-R428) [[13]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L469-R469) [[14]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L499-R499) [[15]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L612-R612) [[16]](diffhunk://#diff-aa8e801ca698bd305a86cfc3c051529adccbc4e00be8078bb4193516ed32cd30L653-R653)

These changes collectively ensure that all transfer and sales toggle operations are tightly coupled to specific, auditable notarizations, improving both security and traceability in the registry module.