### PR TITLE
Update move-docs workflow frontmatter and sidebar

### DIFF
--- a/.github/workflows/move-docs.yml
+++ b/.github/workflows/move-docs.yml
@@ -57,27 +57,19 @@ jobs:
           echo "nav_sort: case_insensitive" >> build/nplex/docs/_config.yml
           echo "baseurl: /hackatonIOTA-MC" >> build/nplex/docs/_config.yml
 
+          # Prepare Frontmatter for the home page (README.md)
+          sed -i "1i---\nlayout: home\ntitle: Home\nnav_order: 1\n---\n" build/nplex/docs/index.md
+
+          # Create a Parent Category Page for the Move Modules so they spawn in the Sidebar
+          echo -e "---\nlayout: default\ntitle: Nplex Smart Contracts\nnav_order: 2\nhas_children: true\n---\n\nQuesta sezione contiene la documentazione tecnica dei moduli Move." > build/nplex/docs/modules_index.md
+
           # Prepare Jekyll Frontmatter for sidebar navigation (tree view)
           # We add this to every Move module markdown file
           for md in build/nplex/docs/nplex/*.md; do
             filename=$(basename "$md" .md)
-            # Prepend frontmatter using sed
-            sed -i "1i---\ntitle: $filename\nparent: Nplex Smart Contracts\n---\n" "$md"
+            # Prepend frontmatter using sed so it appears inside the left sidebar hierarchy
+            sed -i "1i---\nlayout: default\ntitle: $filename\nparent: Nplex Smart Contracts\n---\n" "$md"
           done
-
-          # Prepare Frontmatter for the home page (README.md)
-          sed -i "1i---\ntitle: Home\nnav_order: 1\n---\n" build/nplex/docs/index.md
-
-          # Correct way to inject custom global CSS in 'just-the-docs'
-          # We download it as a plain CSS file inside assets, then include it in the HTML Head.
-          mkdir -p build/nplex/docs/assets/css
-          mkdir -p build/nplex/docs/_includes
-
-          # Fetch FE globals.css directly from private repository
-          curl -H "Authorization: token ${{ secrets.GH_PAT_CLASSIC }}" -sL "https://raw.githubusercontent.com/Sernior/hackatonIOTA-FE/main/src/app/globals.css" > build/nplex/docs/assets/css/globals.css || true
-
-          # Add a custom tag inside the document HEAD to load the globals.css styles
-          echo "<link rel=\"stylesheet\" href=\"{{ '/assets/css/globals.css' | relative_url }}\">" > build/nplex/docs/_includes/head_custom.html
 
       - name: Deploy to GitHub Pages
         # Run deploy only on push to main, skip on PRs


### PR DESCRIPTION
Adjust the .github workflow to better prepare Jekyll frontmatter and sidebar structure for Move docs. Prepends layout/title/nav to index.md, adds a parent modules_index.md so Move modules appear under “Nplex Smart Contracts” in the sidebar, and updates per-module frontmatter to include layout and parent. Also removes the previous steps that fetched and injected a custom globals.css (CSS/HTML head include removed). These changes ensure the docs render with the correct layout and tree navigation.